### PR TITLE
Upgrade to PhantomJS 1.7.0

### DIFF
--- a/lib/phantomjs/platform.rb
+++ b/lib/phantomjs/platform.rb
@@ -76,7 +76,7 @@ module Phantomjs
         end
 
         def package_url
-          'http://phantomjs.googlecode.com/files/phantomjs-1.6.1-linux-x86_64-dynamic.tar.bz2'
+          'http://phantomjs.googlecode.com/files/phantomjs-1.7.0-linux-x86_64.tar.bz2'
         end
       end
     end
@@ -92,7 +92,7 @@ module Phantomjs
         end
 
         def package_url
-          'http://phantomjs.googlecode.com/files/phantomjs-1.6.1-linux-i686-dynamic.tar.bz2'
+          'http://phantomjs.googlecode.com/files/phantomjs-1.7.0-linux-i686.tar.bz2'
         end
       end
     end
@@ -108,7 +108,7 @@ module Phantomjs
         end
 
         def package_url
-          'http://phantomjs.googlecode.com/files/phantomjs-1.6.1-macosx-static.zip'
+          'http://phantomjs.googlecode.com/files/phantomjs-1.7.0-macosx.zip'
         end
       end
     end

--- a/lib/phantomjs/version.rb
+++ b/lib/phantomjs/version.rb
@@ -1,3 +1,3 @@
 module Phantomjs
-  VERSION = "1.6.1.0"
+  VERSION = "1.7.0.0"
 end


### PR DESCRIPTION
I've bumped the PhantomJS version number and added the URLs for PhantomJS 1.7.0.
