### PR TITLE
Make poltergeist dependency optional

### DIFF
--- a/lib/phantomjs/poltergeist.rb
+++ b/lib/phantomjs/poltergeist.rb
@@ -1,6 +1,12 @@
 # encoding: utf-8
 require 'phantomjs'
-require 'capybara/poltergeist'
+
+begin
+  require 'capybara/poltergeist'
+rescue => LoadError 
+  raise "Poltergeist support requires the poltergeist gem to be available."
+end
+
 Phantomjs.path # Force install on require
 Capybara.register_driver :poltergeist do |app|
   Capybara::Poltergeist::Driver.new(app, :phantomjs => Phantomjs.path)

--- a/phantomjs.gemspec
+++ b/phantomjs.gemspec
@@ -8,8 +8,7 @@ Gem::Specification.new do |gem|
   gem.summary       = %q{Auto-install phantomjs on demand for current platform. Comes with poltergeist integration.}
   gem.homepage      = "https://github.com/colszowka/phantomjs-gem"
 
-  gem.add_runtime_dependency 'poltergeist'
-
+  gem.add_developmen_runtime_dependency 'poltergeist'
   gem.add_development_dependency 'rspec', ">= 2.11.0"
   gem.add_development_dependency 'simplecov'
   gem.add_development_dependency 'rake'


### PR DESCRIPTION
Poltergeist is only needed in certain scenarios. Unfortunately, whether or not it is being used, one has to pay the cost of its entire dependency tree (which is quite large!).

Ideally, this would not be a hard dependency.
