### PR TITLE
Upgrade phantomjs to 1.9.1

### DIFF
--- a/lib/phantomjs/platform.rb
+++ b/lib/phantomjs/platform.rb
@@ -94,7 +94,7 @@ module Phantomjs
         end
 
         def package_url
-          'http://phantomjs.googlecode.com/files/phantomjs-1.9.0-linux-x86_64.tar.bz2'
+          'http://phantomjs.googlecode.com/files/phantomjs-1.9.1-linux-x86_64.tar.bz2'
         end
       end
     end
@@ -110,7 +110,7 @@ module Phantomjs
         end
 
         def package_url
-          'http://phantomjs.googlecode.com/files/phantomjs-1.9.0-linux-i686.tar.bz2'
+          'http://phantomjs.googlecode.com/files/phantomjs-1.9.1-linux-i686.tar.bz2'
         end
       end
     end
@@ -126,7 +126,7 @@ module Phantomjs
         end
 
         def package_url
-          'http://phantomjs.googlecode.com/files/phantomjs-1.9.0-macosx.zip'
+          'http://phantomjs.googlecode.com/files/phantomjs-1.9.1-macosx.zip'
         end
       end
     end

--- a/lib/phantomjs/version.rb
+++ b/lib/phantomjs/version.rb
@@ -1,3 +1,3 @@
 module Phantomjs
-  VERSION = "1.9.0.0"
+  VERSION = "1.9.1.0"
 end


### PR DESCRIPTION
Hi,

We have made this change to a newer version of phantomjs on Google Code because we had an issue with PhantomJS intermittently timing out in our Continuous Integration environment. This change now resolves that problem.

Thanks,

Daley Chetwynd
