### PR TITLE
Allow system to have a higher version of PhantomJS installed.

### DIFF
--- a/lib/phantomjs/platform.rb
+++ b/lib/phantomjs/platform.rb
@@ -32,7 +32,8 @@ module Phantomjs
       end
 
       def system_phantomjs_installed?
-        system_phantomjs_version == Phantomjs.version
+        version = system_phantomjs_version
+        version ? version >= Phantomjs.version : false
       end
 
       def installed?

--- a/spec/platform_spec.rb
+++ b/spec/platform_spec.rb
@@ -9,6 +9,12 @@ describe Phantomjs::Platform do
         expect(Phantomjs::Platform.system_phantomjs_installed?).to be_true
       end
 
+      it "is true when the system version is larger than the Phantomjs vesion" do
+        Phantomjs.should_receive(:version).and_return('1.9.2')
+        Phantomjs::Platform.should_receive(:system_phantomjs_version).and_return('1.9.6')
+        expect(Phantomjs::Platform.system_phantomjs_installed?).to be_true
+      end
+
       it "is false when the system version does not match Phantomjs.version" do
         Phantomjs::Platform.should_receive(:system_phantomjs_version).and_return('1.2.3')
         expect(Phantomjs::Platform.system_phantomjs_installed?).to be_false


### PR DESCRIPTION
I have 1.9.6 installed on my machine, but due to the version check to see if PhantomJS is installed, this installs 1.9.2 on my machine. Since this gem is forced on me from the jasmine-rails gem, I have created a patch.
