### PR TITLE
Make base_dir configureable.

### DIFF
--- a/lib/phantomjs.rb
+++ b/lib/phantomjs.rb
@@ -13,6 +13,10 @@ module Phantomjs
        @base_dir ||= File.join(File.expand_path('~'), '.phantomjs', version)
     end
 
+    def base_dir=(dir)
+      @base_dir = dir
+    end
+
     def version
       Phantomjs::VERSION.split('.')[0..-2].join('.')
     end


### PR DESCRIPTION
For my Rails apps, I want to be able to run phantomjs out of the vendor
directory. This change makes that very easy:

1) Create an initializer; config/initializers/phantomjs.rb
2) Set the base_dir:
  Phantomjs.base_dir = Rails.root.join('vendor', 'phantomjs')
