### PR TITLE
CamelCase words in the title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Phantomjs as a Rubygem
+# PhantomJS as a RubyGem
 
 [![Build Status](https://travis-ci.org/colszowka/phantomjs-gem.png?branch=master)](https://travis-ci.org/colszowka/phantomjs-gem)
 


### PR DESCRIPTION
This one is more subjective, but _PhantomJS_ and _RubyGems_ is how they appear in the titles of their [respective](http://phantomjs.org/) [websites](http://rubygems.org/).
