### PR TITLE
check sha-256 checkum of downloaded phantomjs

### DIFF
--- a/lib/phantomjs/platform.rb
+++ b/lib/phantomjs/platform.rb
@@ -55,6 +55,10 @@ module Phantomjs
             raise "\n\nFailed to load phantomjs! :(\nYou need to have cURL or wget installed on your system.\nIf you have, the source of phantomjs might be unavailable: #{package_url}\n\n"
           end
 
+          unless `shasum -a 256 #{File.basename(package_url)}`.split.first == sha256sum
+            raise 'SHA-256 Checksum did not match'
+          end
+
           case package_url.split('.').last
             when 'bz2'
               system "bunzip2 #{File.basename(package_url)}"
@@ -100,6 +104,10 @@ module Phantomjs
         def package_url
           'http://cdn.bitbucket.org/ariya/phantomjs/downloads/phantomjs-1.9.7-linux-x86_64.tar.bz2'
         end
+
+        def sha256sum
+          '473b19f7eacc922bc1de21b71d907f182251dd4784cb982b9028899e91dcb01a'
+        end
       end
     end
 
@@ -116,6 +124,10 @@ module Phantomjs
         def package_url
           'http://cdn.bitbucket.org/ariya/phantomjs/downloads/phantomjs-1.9.7-linux-i686.tar.bz2'
         end
+
+        def sha256sum
+          '2a49bb20ee4b71b8ac1837857a4dddd52f3217d1356afe58e17c5a4e4829cdb9'
+        end
       end
     end
 
@@ -131,6 +143,10 @@ module Phantomjs
 
         def package_url
           'http://cdn.bitbucket.org/ariya/phantomjs/downloads/phantomjs-1.9.7-macosx.zip'
+        end
+
+        def sha256sum
+          '72731f8ff68db17ecb5f6c78bf036adb429317b9bdbe69e2f5f60514fa7e4a6f'
         end
       end
     end
@@ -155,6 +171,10 @@ module Phantomjs
 
         def package_url
           'http://cdn.bitbucket.org/ariya/phantomjs/downloads/phantomjs-1.9.7-windows.zip'
+        end
+
+        def sha256sum
+          '5b2b1c87902fa67f23ae7b9c5f7652d1a4d81b41dc9f260b23e0f6335aa4a65e'
         end
       end
     end


### PR DESCRIPTION
Since the files are downloaded over http, it seems prudent to check the sha256sum.

\- Felix
