### PR TITLE
Fix platform check

### DIFF
--- a/lib/phantomjs/platform.rb
+++ b/lib/phantomjs/platform.rb
@@ -145,6 +145,11 @@ module Phantomjs
           'win32'
         end
 
+        def system_phantomjs_path
+          `where phantomjs`.delete("\n")
+        rescue
+        end
+
         def phantomjs_path
           if system_phantomjs_installed?
             system_phantomjs_path


### PR DESCRIPTION
On Windows, `where` does the job of `which`. This should fix "No such file or directory - which phantomjs". However, I can't figure out how to run your test suite.
