### PR TITLE
Fix wget output filename

### DIFF
--- a/lib/phantomjs/platform.rb
+++ b/lib/phantomjs/platform.rb
@@ -51,7 +51,7 @@ module Phantomjs
         FileUtils.mkdir_p temp_dir
 
         Dir.chdir temp_dir do
-          unless system "curl -L -O #{package_url}" or system "wget #{package_url}"
+          unless system "curl -L -O #{package_url}" or system "wget #{package_url} -O #{File.basename(package_url)}"
             raise "\n\nFailed to load phantomjs! :(\nYou need to have cURL or wget installed on your system.\nIf you have, the source of phantomjs might be unavailable: #{package_url}\n\n"
           end
 


### PR DESCRIPTION
The downloaded file had a query string generated by the repository. Then, the gem wasn't able to find the right file to unzip.

This fix returns only the filename as is done using curl command.
