### PR TITLE
Update PhantomJS 1.9.7 to 1.9.8

### DIFF
--- a/lib/phantomjs/platform.rb
+++ b/lib/phantomjs/platform.rb
@@ -98,7 +98,7 @@ module Phantomjs
         end
 
         def package_url
-          'https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-1.9.7-linux-x86_64.tar.bz2'
+          'https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-1.9.8-linux-x86_64.tar.bz2'
         end
       end
     end
@@ -114,7 +114,7 @@ module Phantomjs
         end
 
         def package_url
-          'https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-1.9.7-linux-i686.tar.bz2'
+          'https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-1.9.8-linux-i686.tar.bz2'
         end
       end
     end
@@ -130,7 +130,7 @@ module Phantomjs
         end
 
         def package_url
-          'https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-1.9.7-macosx.zip'
+          'https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-1.9.8-macosx.zip'
         end
       end
     end
@@ -154,7 +154,7 @@ module Phantomjs
         end
 
         def package_url
-          'https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-1.9.7-windows.zip'
+          'https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-1.9.8-windows.zip'
         end
       end
     end

--- a/lib/phantomjs/version.rb
+++ b/lib/phantomjs/version.rb
@@ -1,3 +1,3 @@
 module Phantomjs
-  VERSION = "1.9.7.1"
+  VERSION = "1.9.8.0"
 end


### PR DESCRIPTION
PhantomJS 1.9.8 includes the following changes:

* Change default SSL protocol to TLSv1 to address POODLE.
  To use the old default protocol of SSLv3 which is vulnerable to POODLE
  add the --ssl-protocol=SSLv3 flag. Reference: http://poodlebleed.com/
* Fixed building on OS X 10.10 Yosemite
* Backported crash fix when exit