### PR TITLE
Update to PhantomJS 1.9.8

### DIFF
--- a/lib/phantomjs/platform.rb
+++ b/lib/phantomjs/platform.rb
@@ -98,7 +98,7 @@ module Phantomjs
         end
 
         def package_url
-          'https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-1.9.7-linux-x86_64.tar.bz2'
+          'https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-1.9.8-linux-x86_64.tar.bz2'
         end
       end
     end
@@ -114,7 +114,7 @@ module Phantomjs
         end
 
         def package_url
-          'https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-1.9.7-linux-i686.tar.bz2'
+          'https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-1.9.8-linux-i686.tar.bz2'
         end
       end
     end
@@ -130,7 +130,7 @@ module Phantomjs
         end
 
         def package_url
-          'https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-1.9.7-macosx.zip'
+          'https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-1.9.8-macosx.zip'
         end
       end
     end
@@ -154,7 +154,7 @@ module Phantomjs
         end
 
         def package_url
-          'https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-1.9.7-windows.zip'
+          'https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-1.9.8-windows.zip'
         end
       end
     end

--- a/lib/phantomjs/version.rb
+++ b/lib/phantomjs/version.rb
@@ -1,3 +1,3 @@
 module Phantomjs
-  VERSION = "1.9.7.1"
+  VERSION = "1.9.8"
 end

--- a/phantomjs.gemspec
+++ b/phantomjs.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency 'poltergeist'
   gem.add_development_dependency 'capybara', '~> 2.0.0'
-  gem.add_development_dependency 'rspec', ">= 2.11.0"
+  gem.add_development_dependency 'rspec', "~> 2.11.0"
   gem.add_development_dependency 'simplecov'
   gem.add_development_dependency 'rake'
 


### PR DESCRIPTION
Also pin RSpec to 2.11.x (for now), since this is not yet compatible with RSpec 3.x.
