### PR TITLE
Various .travis.yml improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
+language: ruby
+sudo: false
 script:
-  - bundle
   - bundle exec rspec
+cache: bundler
 rvm:
   - 1.9
   - 2.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,10 @@ rvm:
   - 2.0
   - 2.1
   - jruby-19mode
+  - rbx
+matrix:
+  allow_failures:
+    - rvm: rbx
 notifications:
   email:
     on_success: always

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,10 @@ language: ruby
 sudo: false
 script:
   - bundle exec rspec
-cache: bundler
+cache:
+  bundler: true
+  directories:
+    - $HOME/.phantomjs
 rvm:
   - 1.9
   - 2.0

--- a/phantomjs.gemspec
+++ b/phantomjs.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency 'poltergeist'
   gem.add_development_dependency 'capybara', '~> 2.0.0'
-  gem.add_development_dependency 'rspec', ">= 2.11.0"
+  gem.add_development_dependency 'rspec', "~> 2.14.0"
   gem.add_development_dependency 'simplecov'
   gem.add_development_dependency 'rake'
 


### PR DESCRIPTION
1. Use `language` key to explicitly indicate Ruby. (While Ruby is the default on Travis CI, this may change in the future.)
2. Send the builds to container-based infrastructure, so that…
3. We can cache gems to speed up builds (`~/.phantomjs` is also included, but I believe something is cleaning up that directory before `rspec`).
4. Run builds on Rubinius, but allow it to fail.

Additionally, we pin RSpec to 2.14.x.
