### PR TITLE
Suppress warnings that phantomjs was not found in $PATH

### DIFF
--- a/lib/phantomjs/platform.rb
+++ b/lib/phantomjs/platform.rb
@@ -22,7 +22,7 @@ module Phantomjs
       end
 
       def system_phantomjs_path
-        `which phantomjs`.delete("\n")
+        `which phantomjs 2> /dev/null`.delete("\n")
       rescue
       end
 


### PR DESCRIPTION
When there is no system wide installed phantomjs you always get a
warning that there is no phantomjs installed, but the tests still work
fine by using the version from the user's home.

That's annyoing and confusing and thus these warnings are now suppressed
by piping them to /dev/null.