### PR TITLE
Update PhantomJS to 2.1.1

### DIFF
--- a/lib/phantomjs/platform.rb
+++ b/lib/phantomjs/platform.rb
@@ -98,7 +98,7 @@ module Phantomjs
         end
 
         def package_url
-          'https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-1.9.8-linux-x86_64.tar.bz2'
+          'https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2'
         end
       end
     end
@@ -114,7 +114,7 @@ module Phantomjs
         end
 
         def package_url
-          'https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-1.9.8-linux-i686.tar.bz2'
+          'https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-i686.tar.bz2'
         end
       end
     end
@@ -130,7 +130,7 @@ module Phantomjs
         end
 
         def package_url
-          'https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-1.9.8-macosx.zip'
+          'https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-macosx.zip'
         end
       end
     end
@@ -149,12 +149,12 @@ module Phantomjs
           if system_phantomjs_installed?
             system_phantomjs_path
           else
-            File.expand_path File.join(Phantomjs.base_dir, platform, 'phantomjs.exe')
+            File.expand_path File.join(Phantomjs.base_dir, platform, 'bin', 'phantomjs.exe')
           end
         end
 
         def package_url
-          'https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-1.9.8-windows.zip'
+          'https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-windows.zip'
         end
       end
     end

--- a/lib/phantomjs/version.rb
+++ b/lib/phantomjs/version.rb
@@ -1,3 +1,3 @@
 module Phantomjs
-  VERSION = "1.9.8.0"
+  VERSION = "2.1.1.0"
 end

--- a/spec/platform_spec.rb
+++ b/spec/platform_spec.rb
@@ -163,7 +163,7 @@ describe Phantomjs::Platform do
       before(:each) { Phantomjs::Platform.stub(:system_phantomjs_version).and_return(nil) }
 
       it "returns the correct phantom js executable path for the platform" do
-        Phantomjs.path.should =~ /win32\/phantomjs.exe$/
+        Phantomjs.path.should =~ /win32\/bin\/phantomjs.exe$/
       end
     end
 

--- a/spec/runner.js
+++ b/spec/runner.js
@@ -1,3 +1,5 @@
-console.log('bar ' + phantom.args[0]);
-console.log('bar ' + phantom.args[1]);
+var system = require('system');
+
+console.log('bar ' + system.args[1]);
+console.log('bar ' + system.args[2]);
 phantom.exit();


### PR DESCRIPTION
The phantom.args got removed, had to use system.args (http://phantomjs.org/api/phantom/property/args.html)

And the windows exe is now inside bin.