### PR TITLE
Fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,5 @@ notifications:
   email:
     on_success: always
     on_failure: always
+before_install:
+  - gem install bundler


### PR DESCRIPTION
The last few builds broken due to an error:

``` ruby
NoMethodError: undefined method `spec' for nil:NilClass
```

This PR fixes it.
