### PR TITLE
Fix Travis builds on Ruby 1.9

### DIFF
--- a/phantomjs.gemspec
+++ b/phantomjs.gemspec
@@ -14,6 +14,9 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rspec', "~> 2.99"
   gem.add_development_dependency 'simplecov'
   gem.add_development_dependency 'rake'
+  if RUBY_VERSION < '2'
+    gem.add_development_dependency "mime-types", "~> 2.6"
+  end
 
   gem.files         = `git ls-files`.split($\)
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }


### PR DESCRIPTION
The mime-types gem versions 3+ no longer supports Ruby < 2.0.
This sets a version constraint for Ruby versions less than 2.