### PR TITLE
Fix for windows x64 machines

### DIFF
--- a/lib/phantomjs/platform.rb
+++ b/lib/phantomjs/platform.rb
@@ -138,7 +138,7 @@ module Phantomjs
     class Win32 < Platform
       class << self
         def useable?
-          host_os.include?('mingw32') and architecture.include?('i686')
+          host_os.include?('mingw32')
         end
 
         def platform
@@ -156,6 +156,12 @@ module Phantomjs
         def package_url
           'https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-windows.zip'
         end
+        
+        def system_phantomjs_path
+          `where phantomjs`.delete("\n")
+        rescue
+        end
+        
       end
     end
   end

--- a/lib/phantomjs/platform.rb
+++ b/lib/phantomjs/platform.rb
@@ -138,7 +138,7 @@ module Phantomjs
     class Win32 < Platform
       class << self
         def useable?
-          host_os.include?('mingw32')
+          !!(host_os =~ /mingw|mswin|cygwin/)
         end
 
         def platform
@@ -158,7 +158,7 @@ module Phantomjs
         end
         
         def system_phantomjs_path
-          `where phantomjs`.delete("\n")
+          `where phantomjs`.delete("\n")[0]
         rescue
         end
         

--- a/spec/platform_spec.rb
+++ b/spec/platform_spec.rb
@@ -170,7 +170,7 @@ describe Phantomjs::Platform do
     describe "with system install" do
       before(:each) do
         Phantomjs::Platform.stub(:system_phantomjs_version).and_return(Phantomjs.version)
-        Phantomjs::Platform.stub(:system_phantomjs_path).and_return("#{ENV['TEMP']}/path")
+        Phantomjs::Platform::Win32.stub(:system_phantomjs_path).and_return("#{ENV['TEMP']}/path")
       end
 
       it "returns the correct phantom js executable path for the platform" do


### PR DESCRIPTION
1. Phatnomjs works for x64 machines so it doesn't have to be validate by architecture.
2. To find phanotm path we use `where`instead of `which`
