### PR TITLE
Ruby downloader

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,10 @@ rvm:
   - 2.0
   - 2.1
   - 2.2
+matrix:
+  exclude:
+    - rvm: 2.2
+      os: osx
 notifications:
   email:
     on_success: always

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 script:
   - bundle
   - bundle exec rspec
+os:
+  - linux
+  - osx
 rvm:
   - 1.9
   - 2.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,9 @@ os:
   - linux
   - osx
 rvm:
-  - 1.9
   - 2.0
   - 2.1
   - 2.2
-  - jruby-19mode
 notifications:
   email:
     on_success: always

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,15 @@ rvm:
   - 1.9
   - 2.0
   - 2.1
-  - 2.2
+  - 2.2.3
   - ruby-head
   - jruby-19mode
+matrix:
+  exclude:
+    - rvm: ruby-head
+      os: osx
+    - rvm: jruby-19mode
+      os: osx
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,11 @@
+# Use the new container-based Travis infrastructure.
+sudo: false
+
+language: ruby
+cache:
+  - bundler
+before_install:
+  - gem install bundler
 script:
   - bundle
   - bundle exec rspec
@@ -5,16 +13,14 @@ os:
   - linux
   - osx
 rvm:
+  - 1.9
   - 2.0
   - 2.1
   - 2.2
-matrix:
-  exclude:
-    - rvm: 2.2
-      os: osx
+  - ruby-head
+  - jruby-19mode
+
 notifications:
   email:
     on_success: always
     on_failure: always
-before_install:
-  - gem install bundler

--- a/README.md
+++ b/README.md
@@ -56,6 +56,19 @@ end
 
 Check out [the poltergeist docs](https://www.ruby-toolbox.com/gems/phantomjs) for all the options you can pass in there.
 
+## Usage with WebMock
+
+WebMock will intercept the download of phantomjs. You may want to disable WebMock while the phantomjs downloader runs, e.g. by adding the following lines to `spec/support/phantomjs.rb`:
+
+```ruby
+begin
+  WebMock.disable!
+  Phantomjs.platform
+ensure
+  WebMock.enable!
+end
+```
+
 ## A note about versions.
 
 The gem version consists of 4 digits: The first 3 indicate the phantomjs release installed via this gem, the last one is the internal version of this gem, in case I screw things up and need to push another release in the interim.

--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@
 I am lazy as hell, and wanted to be able to install [PhantomJS](http://phantomjs.org) via Rubygems/Bundler when using [poltergeist](https://github.com/jonleighton/poltergeist).
 
 It keeps installations of phantomjs in `$HOME/.phantomjs/VERSION/PLATFORM`. When you call `Phantomjs.path`, it will return the path to the phantomjs executable in there. If that is not present, it will first fetch and
-install the prebuilt packages suitable for the current plattform (currently Linux 32/64 or OS X supported).
+install the prebuilt packages suitable for the current plattform (currently Linux 32/64, OS X or Windows supported).
 
 If there is a phantomjs executable in your `$PATH` that matches the version number packaged in this gem, this one will be used instead of installing one in your `$HOME/.phantomjs`.
 
-You will need `cURL` or `wget` on your system. For extraction, `bunzip2` and `tar` are required on Linux, and `unzip` on OS X. They should be installed already.
+For extraction, `bunzip2` and `tar` are required on Linux. They should be installed already.
 
 **TL;DR:** Instead of manually installing phantomjs on your machines, use this gem. It will take care of it.
 

--- a/lib/phantomjs.rb
+++ b/lib/phantomjs.rb
@@ -30,7 +30,7 @@ module Phantomjs
         platform.ensure_installed!
         platform
       else
-        raise UnknownPlatform, "Could not find an appropriate PhantomJS library for your platform (#{RUBY_PLATFORM} :( Please install manually."
+        raise UnknownPlatform, "Could not find an appropriate PhantomJS library for your platform (#{RUBY_PLATFORM}) :( Please install manually."
       end
     end
 

--- a/lib/phantomjs.rb
+++ b/lib/phantomjs.rb
@@ -1,4 +1,4 @@
-require "phantomjs/version"
+require 'phantomjs/version'
 require 'fileutils'
 
 module Phantomjs

--- a/lib/phantomjs/platform.rb
+++ b/lib/phantomjs/platform.rb
@@ -154,7 +154,7 @@ module Phantomjs
     class Win32 < Platform
       class << self
         def useable?
-          host_os.include?('mingw32') and architecture.include?('i686')
+          host_os.include?('mingw32') && (architecture.include?('i686') || architecture.include?('x86_64'))
         end
 
         def platform

--- a/lib/phantomjs/platform.rb
+++ b/lib/phantomjs/platform.rb
@@ -26,8 +26,7 @@ module Phantomjs
       end
 
       def system_phantomjs_path
-        `which phantomjs`.delete("\n")
-      rescue
+        which('phantomjs')
       end
 
       def system_phantomjs_version
@@ -69,6 +68,14 @@ module Phantomjs
       end
 
       private
+      def which(executable)
+        ENV['PATH']
+          .split(File::PATH_SEPARATOR)
+          .map { |path| File.join(path, executable) }
+          .select { |path| File.file?(path) }
+          .first
+      end
+
       def in_tmp
         Dir.mktmpdir('phantomjs_install') do |dir|
           Dir.chdir(dir) do

--- a/lib/phantomjs/platform.rb
+++ b/lib/phantomjs/platform.rb
@@ -161,6 +161,7 @@ module Phantomjs
         FileUtils.mv(extracted_dir, target)
 
         if File.exist?(phantomjs_path)
+          FileUtils.chmod(0755, phantomjs_path)
           STDOUT.puts "\nSuccessfully installed phantomjs in #{phantomjs_path}. Yay!"
           return
         end

--- a/lib/phantomjs/platform.rb
+++ b/lib/phantomjs/platform.rb
@@ -21,12 +21,16 @@ module Phantomjs
         if system_phantomjs_installed?
           system_phantomjs_path
         else
-          File.expand_path File.join(Phantomjs.base_dir, platform, 'bin', 'phantomjs')
+          File.expand_path(File.join(Phantomjs.base_dir, platform, 'bin', phantomjs_executable))
         end
       end
 
+      def phantomjs_executable
+        'phantomjs'
+      end
+
       def system_phantomjs_path
-        which('phantomjs')
+        which(phantomjs_executable)
       end
 
       def system_phantomjs_version
@@ -59,8 +63,6 @@ module Phantomjs
 
           move_to_local_directory
         end
-
-        raise 'Failed to install phantomjs. Sorry :(' unless File.exist?(phantomjs_path)
       end
 
       def ensure_installed!
@@ -156,9 +158,14 @@ module Phantomjs
         target = File.join(Phantomjs.base_dir, platform)
 
         FileUtils.mkdir_p(File.dirname(target))
-        if FileUtils.mv(extracted_dir, target)
-          STDOUT.puts "\nSuccessfully installed phantomjs. Yay!"
+        FileUtils.mv(extracted_dir, target)
+
+        if File.exist?(phantomjs_path)
+          STDOUT.puts "\nSuccessfully installed phantomjs in #{phantomjs_path}. Yay!"
+          return
         end
+
+        fail "Failed to install phantomjs. Could not find #{phantomjs_path}. Sorry :("
       end
     end
 
@@ -218,6 +225,10 @@ module Phantomjs
 
         def platform
           'win32'
+        end
+
+        def phantomjs_executable
+          'phantomjs.exe'
         end
 
         def package_url

--- a/lib/phantomjs/platform.rb
+++ b/lib/phantomjs/platform.rb
@@ -99,6 +99,8 @@ module Phantomjs
           http.request(request) do |response|
             case response
               when Net::HTTPSuccess then
+                STDOUT.puts("Downloading from #{uri}")
+
                 File.open(file, 'wb') do |io|
                   downloaded = 0
 

--- a/lib/phantomjs/platform.rb
+++ b/lib/phantomjs/platform.rb
@@ -128,14 +128,18 @@ module Phantomjs
 
       def bunzip(file)
         bunzip = %W(bunzip2 #{file})
-        system(*bunzip)
+        unless system(*bunzip)
+          fail "Failed to execute \"#{bunzip.join(' ')}\", exit status #{$?.exitstatus}"
+        end
 
         tarfile = file.sub(/\.bz2$/, '')
         directory = File.join(File.basename(tarfile, File.extname(tarfile)), 'bin')
         FileUtils.mkdir_p(directory)
 
         tar = %W(tar -xf #{tarfile} --directory=#{directory})
-        system(*tar)
+        unless system(*tar)
+          fail "Failed to execute \"#{tar.join(' ')}\", exit status #{$?.exitstatus}"
+        end
       end
 
       def unzip(file)

--- a/lib/phantomjs/platform.rb
+++ b/lib/phantomjs/platform.rb
@@ -13,10 +13,6 @@ module Phantomjs
         RbConfig::CONFIG['host_cpu']
       end
 
-      def temp_path
-        ENV['TMPDIR'] || ENV['TEMP'] || '/tmp'
-      end
-
       def phantomjs_path
         if system_phantomjs_installed?
           system_phantomjs_path

--- a/lib/phantomjs/platform.rb
+++ b/lib/phantomjs/platform.rb
@@ -109,7 +109,7 @@ module Phantomjs
                         uri.port,
                         use_ssl: uri.scheme == 'https',
                         verify_mode: OpenSSL::SSL::VERIFY_NONE) do |http|
-          request = Net::HTTP::Get.new(uri)
+          request = Net::HTTP::Get.new(uri.request_uri)
 
           http.request(request) do |response|
             case response

--- a/lib/phantomjs/platform.rb
+++ b/lib/phantomjs/platform.rb
@@ -105,10 +105,10 @@ module Phantomjs
         uri = URI(uri)
         file = File.basename(uri.path)
 
-        Net::HTTP.start(uri.host,
-                        uri.port,
-                        use_ssl: uri.scheme == 'https',
-                        verify_mode: OpenSSL::SSL::VERIFY_NONE) do |http|
+        opts = { use_ssl: uri.scheme == 'https' }
+        opts[:verify_mode] = OpenSSL::SSL::VERIFY_NONE if self == Win32
+
+        Net::HTTP.start(uri.host, uri.port, opts) do |http|
           request = Net::HTTP::Get.new(uri.request_uri)
 
           http.request(request) do |response|

--- a/lib/phantomjs/platform.rb
+++ b/lib/phantomjs/platform.rb
@@ -59,8 +59,7 @@ module Phantomjs
 
           case package_url.split('.').last
             when 'bz2'
-              system "bunzip2 #{File.basename(package_url)}"
-              system "tar xf #{File.basename(package_url).sub(/\.bz2$/, '')}"
+              bunzip(File.basename(package_url))
             when 'zip'
               unzip(File.basename(package_url))
             else
@@ -70,7 +69,7 @@ module Phantomjs
           # Find the phantomjs build we just extracted
           extracted_dir = Dir['phantomjs*'].find { |path| File.directory?(path) }
 
-          fail "Could not find phantomjs binary in #{File.join(Dir.pwd, 'phantomjs*')}" if extracted_dir.nil?
+          fail "Could not find extracted phantomjs directory in #{File.join(Dir.pwd, 'phantomjs*')}" if extracted_dir.nil?
 
           # Move the extracted phantomjs build to $HOME/.phantomjs/version/platform
           if FileUtils.mv extracted_dir, File.join(Phantomjs.base_dir, platform)
@@ -91,6 +90,18 @@ module Phantomjs
       end
 
       private
+      def bunzip(file)
+        bunzip = %W(bunzip2 #{file})
+        system(*bunzip)
+
+        tarfile = file.sub(/\.bz2$/, '')
+        directory = File.join(File.basename(tarfile, File.extname(tarfile)), 'bin')
+        FileUtils.mkdir_p(directory)
+
+        tar = %W(tar -xf #{tarfile} --directory=#{directory})
+        system(*tar)
+      end
+
       def unzip(file)
         # Overwrite existing files.
         Zip.on_exists_proc = true

--- a/lib/phantomjs/platform.rb
+++ b/lib/phantomjs/platform.rb
@@ -129,10 +129,7 @@ module Phantomjs
         end
 
         tarfile = file.sub(/\.bz2$/, '')
-        directory = File.join(File.basename(tarfile, File.extname(tarfile)), 'bin')
-        FileUtils.mkdir_p(directory)
-
-        tar = %W(tar -xf #{tarfile} --directory=#{directory})
+        tar = %W(tar xf #{tarfile})
         unless system(*tar)
           fail "Failed to execute \"#{tar.join(' ')}\", exit status #{$?.exitstatus}"
         end

--- a/lib/phantomjs/platform.rb
+++ b/lib/phantomjs/platform.rb
@@ -181,7 +181,7 @@ module Phantomjs
         end
 
         def package_url
-          'https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2'
+          "https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-#{Phantomjs.version}-linux-x86_64.tar.bz2"
         end
       end
     end
@@ -197,7 +197,7 @@ module Phantomjs
         end
 
         def package_url
-          'https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-i686.tar.bz2'
+          "https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-#{Phantomjs.version}-linux-i686.tar.bz2"
         end
       end
     end
@@ -213,7 +213,7 @@ module Phantomjs
         end
 
         def package_url
-          'https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-macosx.zip'
+          "https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-#{Phantomjs.version}-macosx.zip"
         end
       end
     end
@@ -233,7 +233,7 @@ module Phantomjs
         end
 
         def package_url
-          'https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-windows.zip'
+          "https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-#{Phantomjs.version}-windows.zip"
         end
       end
     end

--- a/phantomjs.gemspec
+++ b/phantomjs.gemspec
@@ -9,6 +9,8 @@ Gem::Specification.new do |gem|
   gem.homepage      = "https://github.com/colszowka/phantomjs-gem"
   gem.license       = 'MIT'
 
+  gem.add_dependency 'rubyzip', '~> 1.0'
+
   gem.add_development_dependency 'poltergeist', '~> 1.5'
   gem.add_development_dependency 'capybara', '~> 2.4'
   gem.add_development_dependency 'rspec', '~> 3.4'

--- a/phantomjs.gemspec
+++ b/phantomjs.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency 'poltergeist', '~> 1.5'
   gem.add_development_dependency 'capybara', '~> 2.4'
-  gem.add_development_dependency 'rspec', "~> 2.99"
+  gem.add_development_dependency 'rspec', '~> 3.4'
   gem.add_development_dependency 'simplecov'
   gem.add_development_dependency 'rake'
   if RUBY_VERSION < '2'
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
   gem.files         = `git ls-files`.split($\)
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
-  gem.name          = "phantomjs"
-  gem.require_paths = ["lib"]
+  gem.name          = 'phantomjs'
+  gem.require_paths = ['lib']
   gem.version       = Phantomjs::VERSION
 end

--- a/spec/phantomjs_spec.rb
+++ b/spec/phantomjs_spec.rb
@@ -13,7 +13,8 @@ HTML_RESPONSE = <<HTML
   </body>
   </html>
 HTML
-Capybara.app = lambda {|env| [200, {"Content-Type" => "text/html"}, [HTML_RESPONSE]] }
+
+Capybara.app = lambda { |_env| [200, { 'Content-Type' => 'text/html' }, [HTML_RESPONSE]] }
 Capybara.default_driver = :poltergeist
 
 describe Phantomjs do
@@ -21,30 +22,30 @@ describe Phantomjs do
     include Capybara::DSL
 
     before { visit '/' }
-    it "has displayed static html content" do
-      within('h1') { page.should have_content('Hello') }
+    it 'has displayed static html content' do
+      within('h1') { expect(page).to have_content('Hello') }
     end
 
-    it "has processed javascript" do
-      within "#js" do
-        page.should_not have_content('NO JS :(')
-        page.should have_content('OMG JS!')
+    it 'has processed javascript' do
+      within '#js' do
+        expect(page).to_not have_content('NO JS :(')
+        expect(page).to have_content('OMG JS!')
       end
     end
   end
 
-  describe ".run" do
-    it "runs phantomjs binary with the correct arguments" do
+  describe '.run' do
+    it 'runs phantomjs binary with the correct arguments' do
       script = File.expand_path('./spec/runner.js')
       result = Phantomjs.run(script, 'foo1', 'foo2')
-      result.should eq("bar foo1\nbar foo2\n")
+      expect(result).to eq("bar foo1\nbar foo2\n")
     end
 
-    it "accepts a block that will get called for each line of output" do
+    it 'accepts a block that will get called for each line of output' do
       lines = []
       script = File.expand_path('./spec/runner.js')
       Phantomjs.run(script, 'foo1', 'foo2') { |line| lines << line }
-      lines.should eq(["bar foo1\n", "bar foo2\n"])
+      expect(lines).to eq(["bar foo1\n", "bar foo2\n"])
     end
   end
 end

--- a/spec/platform_spec.rb
+++ b/spec/platform_spec.rb
@@ -1,241 +1,254 @@
 require 'spec_helper'
 
 describe Phantomjs::Platform do
-  before(:each) { Phantomjs.reset! }
-  describe "with a system install present" do
-    describe "#system_phantomjs_installed?" do
-      it "is true when the system version matches Phantomjs.version" do
-        Phantomjs::Platform.should_receive(:system_phantomjs_version).and_return(Phantomjs.version)
+  before do
+    Phantomjs.reset!
+  end
+
+  describe 'with a system install present' do
+    describe '#system_phantomjs_installed?' do
+      it 'is true when the system version matches Phantomjs.version' do
+        allow(Phantomjs::Platform).to receive(:system_phantomjs_version).and_return(Phantomjs.version)
         expect(Phantomjs::Platform.system_phantomjs_installed?).to be true
       end
 
-      it "is false when the system version does not match Phantomjs.version" do
-        Phantomjs::Platform.should_receive(:system_phantomjs_version).and_return('1.2.3')
+      it 'is false when the system version does not match Phantomjs.version' do
+        allow(Phantomjs::Platform).to receive(:system_phantomjs_version).and_return('1.2.3')
         expect(Phantomjs::Platform.system_phantomjs_installed?).to be false
       end
 
       it "is false when there's no system version" do
-        Phantomjs::Platform.should_receive(:system_phantomjs_version).and_return(nil)
+        allow(Phantomjs::Platform).to receive(:system_phantomjs_version).and_return(nil)
         expect(Phantomjs::Platform.system_phantomjs_installed?).to be false
       end
     end
   end
 
-  describe "on a 64 bit linux" do
+  describe 'on a 64 bit linux' do
     before do
-      Phantomjs::Platform.stub(:host_os).and_return('linux-gnu')
-      Phantomjs::Platform.stub(:architecture).and_return('x86_64')
+      allow(Phantomjs::Platform).to receive(:host_os).and_return('linux-gnu')
+      allow(Phantomjs::Platform).to receive(:architecture).and_return('x86_64')
     end
 
-    it "reports the Linux64 Platform as useable" do
-      Phantomjs::Platform::Linux64.should be_useable
+    it 'reports the Linux64 Platform as useable' do
+      expect(Phantomjs::Platform::Linux64).to be_useable
     end
 
-    describe "without system install" do
-      before(:each) { Phantomjs::Platform.stub(:system_phantomjs_version).and_return(nil) }
+    describe 'without system install' do
+      before do
+        allow(Phantomjs::Platform).to receive(:system_phantomjs_version).and_return(nil)
+      end
 
-      it "returns the correct phantom js executable path for the platform" do
-        Phantomjs.path.should =~ /x86_64-linux\/bin\/phantomjs$/
+      it 'returns the correct phantom js executable path for the platform' do
+        expect(Phantomjs.path).to match(/x86_64-linux\/bin\/phantomjs$/)
       end
     end
 
-    describe "with system install" do
-      before(:each) do
-        Phantomjs::Platform.stub(:system_phantomjs_version).and_return(Phantomjs.version)
-        Phantomjs::Platform.stub(:system_phantomjs_path).and_return('/tmp/path')
+    describe 'with system install' do
+      before do
+        allow(Phantomjs::Platform).to receive(:system_phantomjs_version).and_return(Phantomjs.version)
+        allow(Phantomjs::Platform).to receive(:system_phantomjs_path).and_return('/tmp/path')
       end
 
-      it "returns the correct phantom js executable path for the platform" do
+      it 'returns the correct phantom js executable path for the platform' do
         expect(Phantomjs.path).to be == '/tmp/path'
       end
     end
 
-    it "reports the Linux32 platform as unuseable" do
-      Phantomjs::Platform::Linux32.should_not be_useable
+    it 'reports the Linux32 platform as unuseable' do
+      expect(Phantomjs::Platform::Linux32).not_to be_useable
     end
 
-    it "reports the Darwin platform as unuseable" do
-      Phantomjs::Platform::OsX.should_not be_useable
+    it 'reports the Darwin platform as unuseable' do
+      expect(Phantomjs::Platform::OsX).not_to be_useable
     end
 
-    it "reports the Win32 Platform as unuseable" do
-      Phantomjs::Platform::Win32.should_not be_useable
+    it 'reports the Win32 Platform as unuseable' do
+      expect(Phantomjs::Platform::Win32).not_to be_useable
     end
   end
 
-  describe "on a 32 bit linux" do
+  describe 'on a 32 bit linux' do
     before do
-      Phantomjs::Platform.stub(:host_os).and_return('linux-gnu')
-      Phantomjs::Platform.stub(:architecture).and_return('x86_32')
+      allow(Phantomjs::Platform).to receive(:host_os).and_return('linux-gnu')
+      allow(Phantomjs::Platform).to receive(:architecture).and_return('x86_32')
     end
 
-    it "reports the Linux32 Platform as useable" do
-      Phantomjs::Platform::Linux32.should be_useable
+    it 'reports the Linux32 Platform as useable' do
+      expect(Phantomjs::Platform::Linux32).to be_useable
     end
 
-    it "reports another Linux32 Platform as useable" do
-      Phantomjs::Platform.stub(:host_os).and_return('linux-gnu')
-      Phantomjs::Platform.stub(:architecture).and_return('i686')
-      Phantomjs::Platform::Linux32.should be_useable
+    it 'reports another Linux32 Platform as useable' do
+      allow(Phantomjs::Platform).to receive(:host_os).and_return('linux-gnu')
+      allow(Phantomjs::Platform).to receive(:architecture).and_return('i686')
+      expect(Phantomjs::Platform::Linux32).to be_useable
     end
 
-    describe "without system install" do
-      before(:each) { Phantomjs::Platform.stub(:system_phantomjs_version).and_return(nil) }
+    describe 'without system install' do
+      before do
+        allow(Phantomjs::Platform).to receive(:system_phantomjs_version).and_return(nil)
+      end
 
-      it "returns the correct phantom js executable path for the platform" do
-        Phantomjs.path.should =~ /x86_32-linux\/bin\/phantomjs$/
+      it 'returns the correct phantom js executable path for the platform' do
+        expect(Phantomjs.path).to match(/x86_32-linux\/bin\/phantomjs$/)
       end
     end
 
-    describe "with system install" do
-      before(:each) do
-        Phantomjs::Platform.stub(:system_phantomjs_version).and_return(Phantomjs.version)
-        Phantomjs::Platform.stub(:system_phantomjs_path).and_return('/tmp/path')
+    describe 'with system install' do
+      before do
+        allow(Phantomjs::Platform).to receive(:system_phantomjs_version).and_return(Phantomjs.version)
+        allow(Phantomjs::Platform).to receive(:system_phantomjs_path).and_return('/tmp/path')
       end
 
-      it "returns the correct phantom js executable path for the platform" do
+      it 'returns the correct phantom js executable path for the platform' do
         expect(Phantomjs.path).to be == '/tmp/path'
       end
     end
 
-    it "reports the Linux64 platform as unuseable" do
-      Phantomjs::Platform::Linux64.should_not be_useable
+    it 'reports the Linux64 platform as unuseable' do
+      expect(Phantomjs::Platform::Linux64).not_to be_useable
     end
 
-    it "reports the Darwin platform as unuseable" do
-      Phantomjs::Platform::OsX.should_not be_useable
+    it 'reports the Darwin platform as unuseable' do
+      expect(Phantomjs::Platform::OsX).not_to be_useable
     end
 
-    it "reports the Win32 Platform as unuseable" do
-      Phantomjs::Platform::Win32.should_not be_useable
+    it 'reports the Win32 Platform as unuseable' do
+      expect(Phantomjs::Platform::Win32).not_to be_useable
     end
   end
 
-  describe "on OS X" do
+  describe 'on OS X' do
     before do
-      Phantomjs::Platform.stub(:host_os).and_return('darwin')
-      Phantomjs::Platform.stub(:architecture).and_return('x86_64')
+      allow(Phantomjs::Platform).to receive(:host_os).and_return('darwin')
+      allow(Phantomjs::Platform).to receive(:architecture).and_return('x86_64')
     end
 
-    it "reports the Darwin platform as useable" do
-      Phantomjs::Platform::OsX.should be_useable
+    it 'reports the Darwin platform as useable' do
+      expect(Phantomjs::Platform::OsX).to be_useable
     end
 
-    describe "without system install" do
-      before(:each) { Phantomjs::Platform.stub(:system_phantomjs_version).and_return(nil) }
+    describe 'without system install' do
+      before do
+        allow(Phantomjs::Platform).to receive(:system_phantomjs_version).and_return(nil)
+      end
 
-      it "returns the correct phantom js executable path for the platform" do
-        Phantomjs.path.should =~ /darwin\/bin\/phantomjs$/
+      it 'returns the correct phantom js executable path for the platform' do
+        expect(Phantomjs.path).to match(/darwin\/bin\/phantomjs$/)
       end
     end
 
-    describe "with system install" do
-      before(:each) do
-        Phantomjs::Platform.stub(:system_phantomjs_version).and_return(Phantomjs.version)
-        Phantomjs::Platform.stub(:system_phantomjs_path).and_return('/tmp/path')
+    describe 'with system install' do
+      before do
+        allow(Phantomjs::Platform).to receive(:system_phantomjs_version).and_return(Phantomjs.version)
+        allow(Phantomjs::Platform).to receive(:system_phantomjs_path).and_return('/tmp/path')
       end
 
-      it "returns the correct phantom js executable path for the platform" do
+      it 'returns the correct phantom js executable path for the platform' do
         expect(Phantomjs.path).to be == '/tmp/path'
       end
     end
 
-    it "reports the Linux32 Platform as unuseable" do
-      Phantomjs::Platform::Linux32.should_not be_useable
+    it 'reports the Linux32 Platform as unuseable' do
+      expect(Phantomjs::Platform::Linux32).not_to be_useable
     end
 
-    it "reports the Linux64 platform as unuseable" do
-      Phantomjs::Platform::Linux64.should_not be_useable
+    it 'reports the Linux64 platform as unuseable' do
+      expect(Phantomjs::Platform::Linux64).not_to be_useable
     end
 
-    it "reports the Win32 Platform as unuseable" do
-      Phantomjs::Platform::Win32.should_not be_useable
+    it 'reports the Win32 Platform as unuseable' do
+      expect(Phantomjs::Platform::Win32).not_to be_useable
     end
   end
 
-  describe "on Windows x86" do
+  describe 'on Windows x86' do
     before do
-      Phantomjs::Platform.stub(:host_os).and_return('mingw32')
-      Phantomjs::Platform.stub(:architecture).and_return('i686')
+      allow(Phantomjs::Platform).to receive(:host_os).and_return('mingw32')
+      allow(Phantomjs::Platform).to receive(:architecture).and_return('i686')
     end
 
-    describe "without system install" do
-      before(:each) { Phantomjs::Platform.stub(:system_phantomjs_version).and_return(nil) }
+    describe 'without system install' do
+      before do
+        allow(Phantomjs::Platform).to receive(:system_phantomjs_version).and_return(nil)
+      end
 
-      it "returns the correct phantom js executable path for the platform" do
-        Phantomjs.path.should =~ /win32\/bin\/phantomjs.exe$/
+      it 'returns the correct phantom js executable path for the platform' do
+        expect(Phantomjs.path).to match(/win32\/bin\/phantomjs.exe$/)
       end
     end
 
-    describe "with system install" do
-      before(:each) do
-        Phantomjs::Platform.stub(:system_phantomjs_version).and_return(Phantomjs.version)
-        Phantomjs::Platform.stub(:system_phantomjs_path).and_return("#{ENV['TEMP']}/path")
+    describe 'with system install' do
+      before do
+        allow(Phantomjs::Platform).to receive(:system_phantomjs_version).and_return(Phantomjs.version)
+        allow(Phantomjs::Platform).to receive(:system_phantomjs_path).and_return("#{ENV['TEMP']}/path")
       end
 
-      it "returns the correct phantom js executable path for the platform" do
+      it 'returns the correct phantom js executable path for the platform' do
         expect(Phantomjs.path).to be == "#{ENV['TEMP']}/path"
       end
     end
 
-    it "reports the Darwin platform as unuseable" do
-      Phantomjs::Platform::OsX.should_not be_useable
+    it 'reports the Darwin platform as unuseable' do
+      expect(Phantomjs::Platform::OsX).not_to be_useable
     end
 
-    it "reports the Linux32 Platform as unuseable" do
-      Phantomjs::Platform::Linux32.should_not be_useable
+    it 'reports the Linux32 Platform as unuseable' do
+      expect(Phantomjs::Platform::Linux32).not_to be_useable
     end
 
-    it "reports the Linux64 platform as unuseable" do
-      Phantomjs::Platform::Linux64.should_not be_useable
+    it 'reports the Linux64 platform as unuseable' do
+      expect(Phantomjs::Platform::Linux64).not_to be_useable
     end
   end
 
-  describe "on Windows x64" do
+  describe 'on Windows x64' do
     before do
-      Phantomjs::Platform.stub(:host_os).and_return('mingw32')
-      Phantomjs::Platform.stub(:architecture).and_return('x86_64')
+      allow(Phantomjs::Platform).to receive(:host_os).and_return('mingw32')
+      allow(Phantomjs::Platform).to receive(:architecture).and_return('x86_64')
     end
 
-    describe "without system install" do
-      before(:each) { Phantomjs::Platform.stub(:system_phantomjs_version).and_return(nil) }
+    describe 'without system install' do
+      before do
+        allow(Phantomjs::Platform).to receive(:system_phantomjs_version).and_return(nil)
+      end
 
-      it "returns the correct phantom js executable path for the platform" do
-        Phantomjs.path.should =~ /win32\/bin\/phantomjs.exe$/
+      it 'returns the correct phantom js executable path for the platform' do
+        expect(Phantomjs.path).to match(/win32\/bin\/phantomjs.exe$/)
       end
     end
 
-    describe "with system install" do
-      before(:each) do
-        Phantomjs::Platform.stub(:system_phantomjs_version).and_return(Phantomjs.version)
-        Phantomjs::Platform.stub(:system_phantomjs_path).and_return("#{ENV['TEMP']}/path")
+    describe 'with system install' do
+      before do
+        allow(Phantomjs::Platform).to receive(:system_phantomjs_version).and_return(Phantomjs.version)
+        allow(Phantomjs::Platform).to receive(:system_phantomjs_path).and_return("#{ENV['TEMP']}/path")
       end
 
-      it "returns the correct phantom js executable path for the platform" do
+      it 'returns the correct phantom js executable path for the platform' do
         expect(Phantomjs.path).to be == "#{ENV['TEMP']}/path"
       end
     end
 
-    it "reports the Darwin platform as unuseable" do
-      Phantomjs::Platform::OsX.should_not be_useable
+    it 'reports the Darwin platform as unuseable' do
+      expect(Phantomjs::Platform::OsX).not_to be_useable
     end
 
-    it "reports the Linux32 Platform as unuseable" do
-      Phantomjs::Platform::Linux32.should_not be_useable
+    it 'reports the Linux32 Platform as unuseable' do
+      expect(Phantomjs::Platform::Linux32).not_to be_useable
     end
 
-    it "reports the Linux64 platform as unuseable" do
-      Phantomjs::Platform::Linux64.should_not be_useable
+    it 'reports the Linux64 platform as unuseable' do
+      expect(Phantomjs::Platform::Linux64).not_to be_useable
     end
   end
 
   describe 'on an unknown platform' do
     before do
-      Phantomjs::Platform.stub(:host_os).and_return('foobar')
+      allow(Phantomjs::Platform).to receive(:host_os).and_return('foobar')
     end
 
-    it "raises an UnknownPlatform error" do
-      -> { Phantomjs.platform }.should raise_error(Phantomjs::UnknownPlatform)
+    it 'raises an UnknownPlatform error' do
+      expect { Phantomjs.platform }.to raise_error(Phantomjs::UnknownPlatform)
     end
   end
 end

--- a/spec/platform_spec.rb
+++ b/spec/platform_spec.rb
@@ -6,17 +6,17 @@ describe Phantomjs::Platform do
     describe "#system_phantomjs_installed?" do
       it "is true when the system version matches Phantomjs.version" do
         Phantomjs::Platform.should_receive(:system_phantomjs_version).and_return(Phantomjs.version)
-        expect(Phantomjs::Platform.system_phantomjs_installed?).to be_true
+        expect(Phantomjs::Platform.system_phantomjs_installed?).to be true
       end
 
       it "is false when the system version does not match Phantomjs.version" do
         Phantomjs::Platform.should_receive(:system_phantomjs_version).and_return('1.2.3')
-        expect(Phantomjs::Platform.system_phantomjs_installed?).to be_false
+        expect(Phantomjs::Platform.system_phantomjs_installed?).to be false
       end
 
       it "is false when there's no system version" do
         Phantomjs::Platform.should_receive(:system_phantomjs_version).and_return(nil)
-        expect(Phantomjs::Platform.system_phantomjs_installed?).to be_false
+        expect(Phantomjs::Platform.system_phantomjs_installed?).to be false
       end
     end
   end

--- a/spec/platform_spec.rb
+++ b/spec/platform_spec.rb
@@ -153,7 +153,7 @@ describe Phantomjs::Platform do
     end
   end
 
-  describe "on Windows" do
+  describe "on Windows x86" do
     before do
       Phantomjs::Platform.stub(:host_os).and_return('mingw32')
       Phantomjs::Platform.stub(:architecture).and_return('i686')
@@ -164,6 +164,44 @@ describe Phantomjs::Platform do
 
       it "returns the correct phantom js executable path for the platform" do
         Phantomjs.path.should =~ /win32\/bin\/phantomjs.exe$/
+      end
+    end
+
+    describe "with system install" do
+      before(:each) do
+        Phantomjs::Platform.stub(:system_phantomjs_version).and_return(Phantomjs.version)
+        Phantomjs::Platform.stub(:system_phantomjs_path).and_return("#{ENV['TEMP']}/path")
+      end
+
+      it "returns the correct phantom js executable path for the platform" do
+        expect(Phantomjs.path).to be == "#{ENV['TEMP']}/path"
+      end
+    end
+
+    it "reports the Darwin platform as unuseable" do
+      Phantomjs::Platform::OsX.should_not be_useable
+    end
+
+    it "reports the Linux32 Platform as unuseable" do
+      Phantomjs::Platform::Linux32.should_not be_useable
+    end
+
+    it "reports the Linux64 platform as unuseable" do
+      Phantomjs::Platform::Linux64.should_not be_useable
+    end
+  end
+
+  describe "on Windows x64" do
+    before do
+      Phantomjs::Platform.stub(:host_os).and_return('mingw32')
+      Phantomjs::Platform.stub(:architecture).and_return('x86_64')
+    end
+
+    describe "without system install" do
+      before(:each) { Phantomjs::Platform.stub(:system_phantomjs_version).and_return(nil) }
+
+      it "returns the correct phantom js executable path for the platform" do
+        Phantomjs.path.should =~ /win32\/phantomjs.exe$/
       end
     end
 

--- a/spec/platform_spec.rb
+++ b/spec/platform_spec.rb
@@ -201,7 +201,7 @@ describe Phantomjs::Platform do
       before(:each) { Phantomjs::Platform.stub(:system_phantomjs_version).and_return(nil) }
 
       it "returns the correct phantom js executable path for the platform" do
-        Phantomjs.path.should =~ /win32\/phantomjs.exe$/
+        Phantomjs.path.should =~ /win32\/bin\/phantomjs.exe$/
       end
     end
 

--- a/spec/runner.js
+++ b/spec/runner.js
@@ -1,5 +1,6 @@
 var system = require('system');
+var args = system.args;
 
-console.log('bar ' + system.args[1]);
-console.log('bar ' + system.args[2]);
+console.log('bar ' + args[1]);
+console.log('bar ' + args[2]);
 phantom.exit();

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,4 +8,7 @@ require 'capybara/rspec'
 Phantomjs.implode!
 
 RSpec.configure do |config|
+  config.expect_with(:rspec) do |c|
+    c.syntax = :expect
+  end
 end


### PR DESCRIPTION
1. Pure ruby downloader
2. Extract zip using rubyzip
3. Use gem version to download binaries (2.1.1.42 -> 2.1.1)
4. Supports Windows x64
5. Removed the /tmp cleaning workaround and use proper `Dir.mktmpdir`
6. The call to `which` is replaced by a pure ruby implementation
7. Refactorings

Additional changes:
1. rspec 3.4 with `expect` syntax
2. Use bundler caching on Travis

Relates to #76.
