### PR TITLE
Do not depend on 'which' binary

### DIFF
--- a/lib/phantomjs/platform.rb
+++ b/lib/phantomjs/platform.rb
@@ -1,3 +1,5 @@
+require 'mkmf'
+
 module Phantomjs
   class Platform
     class << self
@@ -22,8 +24,7 @@ module Phantomjs
       end
 
       def system_phantomjs_path
-        `which phantomjs`.delete("\n")
-      rescue
+        find_executable('phantomjs')
       end
 
       def system_phantomjs_version


### PR DESCRIPTION
Not all systems have `which` executable available, so the call `#system_phantomjs_path` will fail silently on such systems.

I replaced `which` with ruby implementation.
