### PR TITLE
I following "which: no phantomjs in" thing to turn off the message

### DIFF
--- a/lib/phantomjs/platform.rb
+++ b/lib/phantomjs/platform.rb
@@ -22,7 +22,7 @@ module Phantomjs
       end
 
       def system_phantomjs_path
-        `which phantomjs`.delete("\n")
+        `which phantomjs 2>/dev/null`.delete("\n")
       rescue
       end
 


### PR DESCRIPTION
…such as it was thought that than can be

``` ruby
$ rails c
Loading development environment (Rails 4.2.6)
irb(main):001:0> Phantomjs.path
which: no phantomjs in (/home/xxxxxxx/.rbenv/versions/2.3.1/bin:/home/xxxxxxx/.rbenv/libexec:/home/xxxxxxx/.rbenv/plugins/ruby-build/bin:...)  <=
which: no phantomjs in (/home/xxxxxxx/.rbenv/versions/2.3.1/bin:/home/xxxxxxx/.rbenv/libexec:/home/xxxxxxx/.rbenv/plugins/ruby-build/bin:...)  <=
=> "/home/xxxxxxx/.phantomjs/2.1.1/x86_64-linux/bin/phantomjs"
```

⬇️ 

``` ruby
$ rails c
Loading development environment (Rails 4.2.6)
irb(main):001:0> Phantomjs.path
=> "/home/xxxxxxx/.phantomjs/2.1.1/x86_64-linux/bin/phantomjs"
```

---

memo 

``` sh
$ ruby -v
ruby 2.3.1p112 (2016-04-26 revision 54768) [x86_64-linux]

$ cat /etc/redhat-release
CentOS Linux release 7.2.1511 (Core)

$ cat /proc/version
Linux version 3.10.0-327.18.2.el7.x86_64 (builder@kbuilder.dev.centos.org) (gcc version 4.8.3 20140911 (Red Hat 4.8.3-9) (GCC) ) #1 SMP Thu May 12 11:03:55 UTC 2016
```
