### PR TITLE
enabling overwriting phantomjs binary package_url through an env variable

### DIFF
--- a/lib/phantomjs/platform.rb
+++ b/lib/phantomjs/platform.rb
@@ -98,7 +98,7 @@ module Phantomjs
         end
 
         def package_url
-          'https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2'
+          ENV['PHANTOMJS_CDNURL'] || 'https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2'
         end
       end
     end
@@ -114,7 +114,7 @@ module Phantomjs
         end
 
         def package_url
-          'https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-i686.tar.bz2'
+          ENV['PHANTOMJS_CDNURL'] || 'https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-i686.tar.bz2'
         end
       end
     end
@@ -130,7 +130,7 @@ module Phantomjs
         end
 
         def package_url
-          'https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-macosx.zip'
+          ENV['PHANTOMJS_CDNURL'] || 'https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-macosx.zip'
         end
       end
     end
@@ -154,7 +154,7 @@ module Phantomjs
         end
 
         def package_url
-          'https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-windows.zip'
+          ENV['PHANTOMJS_CDNURL'] || 'https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-windows.zip'
         end
       end
     end


### PR DESCRIPTION
Hey there,

sometimes I get an error on my CI box because bitbucket blocks frequent downloads of the file. This seems to be a common problema (https://github.com/ariya/phantomjs/issues/13951) but it wasn't yet addressed on this gem.

I've added some code to enable overwriting the default package download url with an env variable, just like the people at Medium do - https://github.com/Medium/phantomjs#deciding-where-to-get-phantomjs

What do you think?

(I thought about adding another method that either uses the env variable or delegates to `package_url` but then it would be a deeper change. Anyway.)
