### PR TITLE
Implode Phantomjs when installed in custom base dir.

### DIFF
--- a/lib/phantomjs.rb
+++ b/lib/phantomjs.rb
@@ -36,7 +36,7 @@ module Phantomjs
 
     # Removes the local phantomjs copy
     def implode!
-      FileUtils.rm_rf File.join(File.expand_path('~'), '.phantomjs')
+      FileUtils.rm_rf base_dir
     end
 
     # Clears cached state. Primarily useful for testing.

--- a/spec/phantomjs_spec.rb
+++ b/spec/phantomjs_spec.rb
@@ -47,4 +47,13 @@ describe Phantomjs do
       lines.should eq(["bar foo1\n", "bar foo2\n"])
     end
   end
+
+  describe ".implode!" do
+    it "removes the local phantomjs copy from custom base_dir" do
+      Phantomjs.base_dir = '/tmp/base_dir'
+      Phantomjs.path.platform.installed?.should be_true
+      Phantomjs.implode!
+      Dir.exist?('/tmp/base_dir').should be_false
+    end
+  end
 end


### PR DESCRIPTION
Base dir for installation of phantomjs is configurable by setting `Phantomjs.base_dir`, but `Phantomjs.implode!` disregards that setting and always removes directory `~/.phantomjs`. We resolve the discrepancy by making `Phantomjs.implode!` remove configured base dir.
