### PR TITLE
Build for 2.5.0-beta?

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,13 @@
+# Use Ubuntu 14.04
+dist: trusty
+# Container-based builds
+sudo: false
 script:
   - bundle
   - bundle exec rspec
+cache:
+  - apt
+  - bundler
 rvm:
   - 1.9
   - 2.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,16 @@ rvm:
   - 2.1
   - 2.2
   - jruby-19mode
+addons:
+  apt:
+    sources:
+      - sourceline: 'ppa:ubuntu-toolchain-r/test'
+    packages:
+      - libicu-dev
+      - libhyphen0
+      - webp
+      - gcc-4.9
+      - g++-4.9
 notifications:
   email:
     on_success: always

--- a/lib/phantomjs.rb
+++ b/lib/phantomjs.rb
@@ -55,7 +55,6 @@ module Phantomjs
 end
 
 require 'phantomjs/platform'
-Phantomjs.available_platforms << Phantomjs::Platform::Linux32
 Phantomjs.available_platforms << Phantomjs::Platform::Linux64
 Phantomjs.available_platforms << Phantomjs::Platform::OsX
 Phantomjs.available_platforms << Phantomjs::Platform::Win32

--- a/lib/phantomjs/platform.rb
+++ b/lib/phantomjs/platform.rb
@@ -59,6 +59,8 @@ module Phantomjs
             when 'bz2'
               system "bunzip2 #{File.basename(package_url)}"
               system "tar xf #{File.basename(package_url).sub(/\.bz2$/, '')}"
+            when 'gz'
+              system "tar zxf #{File.basename(package_url)}"
             when 'zip'
               system "unzip #{File.basename(package_url)}"
             else

--- a/lib/phantomjs/platform.rb
+++ b/lib/phantomjs/platform.rb
@@ -143,7 +143,7 @@ module Phantomjs
         end
 
         def package_url
-          'https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.5.0-beta-windows.zip'
+          'https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.5.0-beta2-windows.zip'
         end
       end
     end

--- a/lib/phantomjs/platform.rb
+++ b/lib/phantomjs/platform.rb
@@ -103,22 +103,6 @@ module Phantomjs
       end
     end
 
-    class Linux32 < Platform
-      class << self
-        def useable?
-          host_os.include?('linux') and (architecture.include?('x86_32') or architecture.include?('i686'))
-        end
-
-        def platform
-          'x86_32-linux'
-        end
-
-        def package_url
-          'https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-i686.tar.bz2'
-        end
-      end
-    end
-
     class OsX < Platform
       class << self
         def useable?

--- a/lib/phantomjs/platform.rb
+++ b/lib/phantomjs/platform.rb
@@ -75,6 +75,10 @@ module Phantomjs
             STDOUT.puts "\nSuccessfully installed phantomjs. Yay!"
           end
 
+          if File.exist?(phantomjs_path) and not File.executable?(phantomjs_path)
+            File.chmod 755, phantomjs_path
+          end
+
           # Clean up remaining files in tmp
           if FileUtils.rm_rf temp_dir
             STDOUT.puts "Removed temporarily downloaded files."

--- a/lib/phantomjs/platform.rb
+++ b/lib/phantomjs/platform.rb
@@ -98,7 +98,7 @@ module Phantomjs
         end
 
         def package_url
-          'https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2'
+          'https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.5.0-beta-linux-ubuntu-trusty-x86_64.tar.gz'
         end
       end
     end
@@ -114,7 +114,7 @@ module Phantomjs
         end
 
         def package_url
-          'https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-macosx.zip'
+          'https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.5.0-beta-macos.zip'
         end
       end
     end
@@ -138,7 +138,7 @@ module Phantomjs
         end
 
         def package_url
-          'https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-windows.zip'
+          'https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.5.0-beta-windows.zip'
         end
       end
     end

--- a/lib/phantomjs/platform.rb
+++ b/lib/phantomjs/platform.rb
@@ -57,8 +57,7 @@ module Phantomjs
 
           case package_url.split('.').last
             when 'bz2'
-              system "bunzip2 #{File.basename(package_url)}"
-              system "tar xf #{File.basename(package_url).sub(/\.bz2$/, '')}"
+              system "tar jxf #{File.basename(package_url)}"
             when 'gz'
               system "tar zxf #{File.basename(package_url)}"
             when 'zip'

--- a/lib/phantomjs/version.rb
+++ b/lib/phantomjs/version.rb
@@ -1,3 +1,3 @@
 module Phantomjs
-  VERSION = "2.1.1.0"
+  VERSION = "2.5.0.beta.0"
 end

--- a/spec/platform_spec.rb
+++ b/spec/platform_spec.rb
@@ -50,58 +50,6 @@ describe Phantomjs::Platform do
       end
     end
 
-    it "reports the Linux32 platform as unuseable" do
-      Phantomjs::Platform::Linux32.should_not be_useable
-    end
-
-    it "reports the Darwin platform as unuseable" do
-      Phantomjs::Platform::OsX.should_not be_useable
-    end
-
-    it "reports the Win32 Platform as unuseable" do
-      Phantomjs::Platform::Win32.should_not be_useable
-    end
-  end
-
-  describe "on a 32 bit linux" do
-    before do
-      Phantomjs::Platform.stub(:host_os).and_return('linux-gnu')
-      Phantomjs::Platform.stub(:architecture).and_return('x86_32')
-    end
-
-    it "reports the Linux32 Platform as useable" do
-      Phantomjs::Platform::Linux32.should be_useable
-    end
-
-    it "reports another Linux32 Platform as useable" do
-      Phantomjs::Platform.stub(:host_os).and_return('linux-gnu')
-      Phantomjs::Platform.stub(:architecture).and_return('i686')
-      Phantomjs::Platform::Linux32.should be_useable
-    end
-
-    describe "without system install" do
-      before(:each) { Phantomjs::Platform.stub(:system_phantomjs_version).and_return(nil) }
-
-      it "returns the correct phantom js executable path for the platform" do
-        Phantomjs.path.should =~ /x86_32-linux\/bin\/phantomjs$/
-      end
-    end
-
-    describe "with system install" do
-      before(:each) do
-        Phantomjs::Platform.stub(:system_phantomjs_version).and_return(Phantomjs.version)
-        Phantomjs::Platform.stub(:system_phantomjs_path).and_return('/tmp/path')
-      end
-
-      it "returns the correct phantom js executable path for the platform" do
-        expect(Phantomjs.path).to be == '/tmp/path'
-      end
-    end
-
-    it "reports the Linux64 platform as unuseable" do
-      Phantomjs::Platform::Linux64.should_not be_useable
-    end
-
     it "reports the Darwin platform as unuseable" do
       Phantomjs::Platform::OsX.should_not be_useable
     end
@@ -140,10 +88,6 @@ describe Phantomjs::Platform do
       end
     end
 
-    it "reports the Linux32 Platform as unuseable" do
-      Phantomjs::Platform::Linux32.should_not be_useable
-    end
-
     it "reports the Linux64 platform as unuseable" do
       Phantomjs::Platform::Linux64.should_not be_useable
     end
@@ -180,10 +124,6 @@ describe Phantomjs::Platform do
 
     it "reports the Darwin platform as unuseable" do
       Phantomjs::Platform::OsX.should_not be_useable
-    end
-
-    it "reports the Linux32 Platform as unuseable" do
-      Phantomjs::Platform::Linux32.should_not be_useable
     end
 
     it "reports the Linux64 platform as unuseable" do


### PR DESCRIPTION
PhantomJS 2.5.0-beta was released earlier this year and works ok for me on a mac.  I haven't tested it anywhere else.

It's worth getting this beta in more people's hands, IMO, to support upstream development.   Would it be possible to just push a beta version to rubygems.org for now?  I'm not suggesting this get merged to master.  Maybe just make a 2.5 branch for now?

Despite the news that the current PhantomJS maintainer left to work on a headless Web development tool targeting Chromium, there is a lot of work and improvements in PhantomJS 2.5.0.  The pre-releases should start getting exposed in hopes of improving the chance of a stable release.

Thanks for phantomjs-gem!