### PR TITLE
Add Appveyor build file

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,27 @@
+# appveyor.yml
+
+environment:
+  matrix:
+    - RUBY_VERSION: 23
+    - RUBY_VERSION: 22
+    - RUBY_VERSION: 21
+    - RUBY_VERSION: 200
+    - RUBY_VERSION: 193
+
+platform:
+  - x86
+  - x64
+
+install:
+  - set PATH=C:\Ruby%RUBY_VERSION%\bin;%PATH%
+  - bundle install
+
+build: off
+
+before_test:
+  - ruby -v
+  - gem -v
+  - bundle -v
+
+test_script:
+  - bundle exec rspec


### PR DESCRIPTION
This will be useful for verifying the gem works on Windows in the next release of phantomjs, 2.5.0.

~~It required some changes to the dependencies in the gemspec.~~  Actually, I knew this back in #96 